### PR TITLE
Stylise the caret element to look more close to real

### DIFF
--- a/ptty.jquery.js
+++ b/ptty.jquery.js
@@ -208,7 +208,7 @@
                     'div.prompt div.input::before'+
                         '{ vertical-align: middle; content: attr(data-ps); }',
                     'div.prompt div.input::after'+
-                        '{ visibility : visible; vertical-align: middle; content: attr(data-caret); left:-4px; position:relative; font-family:monospace; }',
+                        '{ visibility : visible; vertical-align: middle; content: attr(data-caret); margin-left:-0.15em;}',
                     'div.prompt div.input.blink::after'+
                         '{ visibility : hidden; }',
                     'div.prompt .hide'+

--- a/ptty.jquery.js
+++ b/ptty.jquery.js
@@ -208,7 +208,7 @@
                     'div.prompt div.input::before'+
                         '{ vertical-align: middle; content: attr(data-ps); }',
                     'div.prompt div.input::after'+
-                        '{ visibility : visible; vertical-align: middle; content: attr(data-caret); }',
+                        '{ visibility : visible; vertical-align: middle; content: attr(data-caret); left:-4px; position:relative; font-family:monospace; }',
                     'div.prompt div.input.blink::after'+
                         '{ visibility : hidden; }',
                     'div.prompt .hide'+


### PR DESCRIPTION
This PR updates ptty.jquery.js in the styles section to add styling to a cursor element to make it look more realistic.
Here's comparison:
<img width="266" alt="screen shot 2018-07-31 at 21 22 56" src="https://user-images.githubusercontent.com/1363772/43482079-fdd85584-9507-11e8-9f5c-39050635364a.png">
<img width="230" alt="screen shot 2018-07-31 at 21 21 51" src="https://user-images.githubusercontent.com/1363772/43482080-fdf04338-9507-11e8-954b-4e1c2131ee09.png">
